### PR TITLE
Fix for multiple definition of comDat

### DIFF
--- a/wiringPiD/drcNetCmd.h
+++ b/wiringPiD/drcNetCmd.h
@@ -34,11 +34,19 @@
 #define	DRCN_DIGITAL_READ8	8
 #define	DRCN_ANALOG_READ	9
 
-
+// Multiple definition for comDat fix
+/*
 struct drcNetComStruct
 {
   uint32_t pin ;
   uint32_t cmd ;
   uint32_t data ;
 } comDat ;
+*/
 
+struct drcNetComStruct
+{
+  uint32_t pin ;
+  uint32_t cmd ;
+  uint32_t data ;
+};


### PR DESCRIPTION
Armbian 22.11.0 comes with GCC v10+, on which the build unfortunately fails with the following error:

```
/usr/bin/ld: wpiExtensions.o:(.bss+0x404): multiple definition of `comDat'; drcNet.o:(.bss+0x400): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:82: libwiringPi.so.2.44] Error 1
```

This issue was also present in the original RPi WiringPi build as seen in this [Issue](https://github.com/WiringPi/WiringPi-Python/issues/73) and was fixed through the commit that I've provided in this PR.